### PR TITLE
Fixed error on first clean build.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
     <!--  lint (http://www.jslint.com/lint.html) -->
     <target name="lint">
         <!-- ant lint -Dfile=src/cajal.js -->
-        <java jar="build/js.jar">
+        <java jar="build/js.jar" fork="true">
             <arg value="build/jslint-check.js" />
             <arg value="${file}" />
         </java>


### PR DESCRIPTION
build.xml:8: Cannot execute a jar in non-forked mode. Please set fork='true'. 

ant -version
Apache Ant(TM) version 1.8.2 compiled on June 3 2011
