### PR TITLE
Update package.json to provide entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "email": "rendro87@gmail.com",
     "url": "http://robert-fleischmann.de"
   },
+  "main": "./dist/vintage.js",
   "devDependencies": {
     "grunt": "*",
     "grunt-contrib-uglify": "*",


### PR DESCRIPTION
Updates package.json to provide a reference to the entry point to facilitate inclusion using browserify and other commonjs systems.

As it stands the only way to successfully import vintagejs when using npm is `require('vintagejs/dist/vintage.js')` when ideally it should be `require('vintagejs')`